### PR TITLE
Visiting a ~username was redirecting to ~username/

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -8,7 +8,7 @@ urlpatterns = patterns('charref.characters.views',
     (r'^ng/', 'ng'),
     (r'^app/', 'app'),
 
-    (r'^~(?P<username>[a-zA-Z0-9\-_ ]+)/$', 'show_user'),
+    (r'^~(?P<username>[a-zA-Z0-9\-_ ]+)/?$', 'show_user'),
     (r'^~(?P<username>[a-zA-Z0-9\-_ ]+)/edit/$', 'edit_user'),
     (r'^register/$', 'register'),
     (r'^users/$', 'list_users'),


### PR DESCRIPTION
After that redirect, some helpful JS is removing the trailing slash. Adjust urls.py so that ~username is a valid URL.

This was doing something weird with my back button in chrome - after visiting a user page, clicking back took me to the characters homepage rather than back to wherever I was.

There's also some code in user/show.html on line 6 that seems to be related.. but I left it alone for now.
